### PR TITLE
Support riscv64 for tflite v2.4.1

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -10,4 +10,4 @@ BBFILE_PATTERN_meta-tensorflow-lite = "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-tensorflow-lite = "6"
 
 LAYERDEPENDS_meta-tensorflow-lite = "core"
-LAYERSERIES_COMPAT_meta-tensorflow-lite = "warrior zeus dunfell"
+LAYERSERIES_COMPAT_meta-tensorflow-lite = "warrior zeus dunfell gatesgarth"

--- a/recipes-framework/tensorflow-lite/files/link-atomic-lib.patch
+++ b/recipes-framework/tensorflow-lite/files/link-atomic-lib.patch
@@ -1,0 +1,27 @@
+diff --git a/tensorflow/lite/tools/make/Makefile b/tensorflow/lite/tools/make/Makefile
+index 9d90e9526be..1ba137304e7 100644
+--- a/tensorflow/lite/tools/make/Makefile
++++ b/tensorflow/lite/tools/make/Makefile
+@@ -57,7 +57,8 @@ LIBS := \
+ -lpthread \
+ -lm \
+ -lz \
+--ldl
++-ldl \
++-latomic
+
+ # There are no rules for compiling objects for the host system (since we don't
+ # generate things like the protobuf compiler that require that), so all of
+diff --git a/tensorflow/lite/tools/pip_package/setup.py b/tensorflow/lite/tools/pip_package/setup.py
+index 8c122418abd..5ccd40683b1 100644
+--- a/tensorflow/lite/tools/pip_package/setup.py
++++ b/tensorflow/lite/tools/pip_package/setup.py
+@@ -178,7 +178,7 @@ ext = Extension(
+         os.path.join(DOWNLOADS_DIR, 'absl'),
+         #pybind11.get_include()
+     ],
+-    libraries=[LIB_TFLITE],
++    libraries=[LIB_TFLITE, 'atomic'],
+     library_dirs=[LIB_TFLITE_DIR])
+
+ setup(

--- a/recipes-framework/tensorflow-lite/python3-tensorflow-lite_2.4.1.bb
+++ b/recipes-framework/tensorflow-lite/python3-tensorflow-lite_2.4.1.bb
@@ -15,6 +15,10 @@ SRC_URI = " \
     file://001-Remove-toolchain-setup-and-pybind11.patch \
 "
 
+SRC_URI_append_riscv64 += " \
+    file://link-atomic-lib.patch \
+"
+
 S = "${WORKDIR}/git"
 
 DEPENDS += "gzip-native \
@@ -83,6 +87,15 @@ do_compile() {
         STAGING_LIBDIR=${STAGING_LIBDIR} \
         ${STAGING_BINDIR_NATIVE}/${PYTHON_PN}-native/${PYTHON_PN} setup.py \
         bdist --plat-name=linux-armv7l bdist_wheel --plat-name=linux-armv7l
+    elif [ ${TARGET_ARCH} = "riscv64" ]; then
+        echo "build riscv64"
+        export TENSORFLOW_TARGET=riscv64
+        export TARGET=riscv64
+
+        STAGING_INCDIR=${STAGING_INCDIR} \
+        STAGING_LIBDIR=${STAGING_LIBDIR} \
+        ${STAGING_BINDIR_NATIVE}/${PYTHON_PN}-native/${PYTHON_PN} setup.py \
+        bdist --plat-name=linux-riscv64 bdist_wheel --plat-name=linux-riscv64
     fi
 }
 


### PR DESCRIPTION
Hi Nobuo Tsukamoto,

I am a software engineer from SiFive. I am porting `meta-tensorflow-lite` for riscv platform. In this PR, I add the riscv64 support for TFLite v2.4.1 and add `gatesgarth` to layer compatibility list.

Thanks