### PR TITLE
python3-tensorflow-lite_2.5.0: add missing (metrics) files

### DIFF
--- a/recipes-framework/tensorflow-lite/python3-tensorflow-lite_2.5.0.bb
+++ b/recipes-framework/tensorflow-lite/python3-tensorflow-lite_2.5.0.bb
@@ -60,6 +60,8 @@ do_compile() {
           "${TENSORFLOW_LITE_DIR}/python/interpreter_wrapper" \
           "${LOCAL_BUILD_DIR}"
     cp "${TENSORFLOW_LITE_DIR}/python/interpreter.py" \
+       "${TENSORFLOW_LITE_DIR}/python/metrics_interface.py" \
+       "${TENSORFLOW_LITE_DIR}/python/metrics_portable.py" \
        "${LOCAL_BUILD_DIR}/tflite_runtime"
     echo "__version__ = '${PACKAGE_VERSION}'" >> "${LOCAL_BUILD_DIR}/tflite_runtime/__init__.py"
     echo "__git_version__ = '$(git -C "${TENSORFLOW_DIR}" describe)'" >> "${LOCAL_BUILD_DIR}/tflite_runtime/__init__.py"


### PR DESCRIPTION
Fixes:

    Traceback (most recent call last):
      File "/usr/share/doc/python3-tensorflow-lite-demo/example/mnist.py", line 2, in <module>
        import tflite_runtime.interpreter as tflite
      File "/usr/lib/python3.9/site-packages/tflite_runtime/interpreter.py", line 42, in <module>
        from tflite_runtime import metrics_portable as metrics
    ImportError: cannot import name 'metrics_portable' from 'tflite_runtime' (/usr/lib/python3.9/site-packages/tflite_runtime/__init__.py)

See:
- https://github.com/tensorflow/tensorflow/commit/36917c0d825f1abb49a62869fa469c74739b5818
- https://github.com/tensorflow/tensorflow/commit/5f2341e61bc5e5172f521fffd1a0851146891c2a

Signed-off-by: David Abdurachmanov <david.abdurachmanov@sifive.com>