### PR TITLE
cpp-tensorflow-lite: add symbolic link to libtensorflowlite.so

### DIFF
--- a/recipes-framework/tensorflow-lite/cpp-tensorflow-lite_2.6.0.bb
+++ b/recipes-framework/tensorflow-lite/cpp-tensorflow-lite_2.6.0.bb
@@ -32,7 +32,9 @@ EXTRA_OECMAKE += "-DBUILD_SHARED_LIBS=ON"
 
 do_install() {
     install -d ${D}/${libdir}
-    install -m 0644 ${B}/libtensorflow-lite.so  ${D}/${libdir}/libtensorflowlite.so
+    install -m 0644 ${B}/libtensorflow-lite.so  ${D}/${libdir}/
+    ln -s -r ${D}/${libdir}/libtensorflow-lite.so ${D}/${libdir}/libtensorflowlite.so
+
     install -m 0644 ${B}/_deps/farmhash-build/libfarmhash.so ${D}/${libdir}
     install -m 0644 ${B}/_deps/fft2d-build/libfft2d_fftsg2d.so ${D}/${libdir}
     install -m 0644 ${B}/_deps/ruy-build/libruy.so ${D}/${libdir}


### PR DESCRIPTION
Tensorflow lite CPP library can be built both by using Bazel and
by using Cmake.
Apparently, Bazel produces libtensorflowlite.so and Cmake produces libtensorflow-lite.so.
Install the libtensorflow-lite.so version and create a symbolic link for libtensorflowlite.so
to support Bazel built applications as well.