### PR TITLE
oe-core switched to mickledore [1]

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -10,4 +10,4 @@ BBFILE_PATTERN_meta-tensorflow-lite = "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-tensorflow-lite = "6"
 
 LAYERDEPENDS_meta-tensorflow-lite = "core"
-LAYERSERIES_COMPAT_meta-tensorflow-lite = "langdale"
+LAYERSERIES_COMPAT_meta-tensorflow-lite = "mickledore"


### PR DESCRIPTION
[1] https://git.openembedded.org/openembedded-core/commit/?id=57239d66b933c4313cf331d35d13ec2d0661c38f

Signed-off-by: Thomas Perrot <thomas.perrot@bootlin.com>