### PR TITLE
python3-tensorflow-lite: PYTHONPATH is already defined

### DIFF
--- a/.github/workflows/build_riscv.yml
+++ b/.github/workflows/build_riscv.yml
@@ -16,8 +16,8 @@ on:
   workflow_dispatch:
 
 env:
-  TARGET_VERSION: langdale
-  TARGET_BITBAKE_VERSION: 2.2
+  TARGET_VERSION: master
+  TARGET_BITBAKE_VERSION: master
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/.github/workflows/build_rpi.yml
+++ b/.github/workflows/build_rpi.yml
@@ -16,7 +16,7 @@ on:
   workflow_dispatch:
 
 env:
-  TARGET_VERSION: langdale
+  TARGET_VERSION: master
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/recipes-framework/tensorflow-lite/python3-tensorflow-lite_2.11.0.bb
+++ b/recipes-framework/tensorflow-lite/python3-tensorflow-lite_2.11.0.bb
@@ -48,7 +48,7 @@ OECMAKE_CXX_FLAGS += "-I${PYTHON_INCLUDE_DIR} -I${PYBIND11_INCLUDE} -I${NUMPY_IN
 CMAKE_VERBOSE = "VERBOSE=1"
 
 # Note:
-# XNNPack is valid only on 64bit. 
+# XNNPack is valid only on 64bit.
 # In the case of arm 32bit, it will be turned off because the build will be
 # an error depending on the combination of target CPUs.
 TENSORFLOW_TARGET_ARCH:raspberrypi = "armv6"
@@ -143,14 +143,13 @@ do_compile:append() {
 do_install() {
     echo "Generating pip package"
     cd "${TENSORFLOW_LITE_BUILD_DIR}"
-    
+
     install -d ${D}/${PYTHON_SITEPACKAGES_DIR}
 
     echo ${D}/${PYTHON_SITEPACKAGES_DIR}
 
     TAGING_INCDIR=${STAGING_INCDIR} \
     STAGING_LIBDIR=${STAGING_LIBDIR} \
-    PYTHONPATH=${D}${PYTHON_SITEPACKAGES_DIR} \
     ${STAGING_BINDIR_NATIVE}/${PYTHON_PN}-native/${PYTHON_PN} -m pip install --disable-pip-version-check -v \
     -t ${D}/${PYTHON_SITEPACKAGES_DIR} --no-cache-dir --no-deps \
     ${S}/tensorflow/lite/tools/pip_package/gen/tflite_pip/python3/dist/tflite_runtime-${DPV}*.whl


### PR DESCRIPTION
Since the commit c9617c03bcee from oe-core, the PYTHONPATH is now correctly extended.

In addition, the redefinition of the PYTHONPATH in this recipe leads to the following build issue:

|     site_packages: typing.Optional[str] = sysconfig.get_path("purelib")
|                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
|   File "/home/runner/work/meta-tensorflow-lite/rpi-build/tmp/work/arm1176jzfshf-vfp-poky-linux-gnueabi/python3-tensorflow-lite/2.11.0-r0/recipe-sysroot-native/usr/lib/python3.11/sysconfig.py", line 626, in get_path
|     return get_paths(scheme, vars, expand)[name]
|            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
|   File "/home/runner/work/meta-tensorflow-lite/rpi-build/tmp/work/arm1176jzfshf-vfp-poky-linux-gnueabi/python3-tensorflow-lite/2.11.0-r0/recipe-sysroot-native/usr/lib/python3.11/sysconfig.py", line 616, in get_paths
|     return _expand_vars(scheme, vars)
|            ^^^^^^^^^^^^^^^^^^^^^^^^^^
|   File "/home/runner/work/meta-tensorflow-lite/rpi-build/tmp/work/arm1176jzfshf-vfp-poky-linux-gnueabi/python3-tensorflow-lite/2.11.0-r0/recipe-sysroot-native/usr/lib/python3.11/sysconfig.py", line 265, in _expand_vars
|     _extend_dict(vars, get_config_vars())
|                        ^^^^^^^^^^^^^^^^^
|   File "/home/runner/work/meta-tensorflow-lite/rpi-build/tmp/work/arm1176jzfshf-vfp-poky-linux-gnueabi/python3-tensorflow-lite/2.11.0-r0/recipe-sysroot-native/usr/lib/python3.11/sysconfig.py", line 670, in get_config_vars
|     _init_posix(_CONFIG_VARS)
|   File "/home/runner/work/meta-tensorflow-lite/rpi-build/tmp/work/arm1176jzfshf-vfp-poky-linux-gnueabi/python3-tensorflow-lite/2.11.0-r0/recipe-sysroot-native/usr/lib/python3.11/sysconfig.py", line 531, in _init_posix
|     _temp = __import__(name, globals(), locals(), ['build_time_vars'], 0)

Signed-off-by: Thomas Perrot <thomas.perrot@bootlin.com>