### PR TITLE
recipes: Use UNPACKDIR instead of WORKDIR

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -10,4 +10,4 @@ BBFILE_PATTERN_meta-tensorflow-lite = "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-tensorflow-lite = "6"
 
 LAYERDEPENDS_meta-tensorflow-lite = "core"
-LAYERSERIES_COMPAT_meta-tensorflow-lite = "nanbield scarthgap"
+LAYERSERIES_COMPAT_meta-tensorflow-lite = "styhead"

--- a/recipes-examples/tensorflow-lite/python3-tensorflow-lite-example_2.16.1.bb
+++ b/recipes-examples/tensorflow-lite/python3-tensorflow-lite-example_2.16.1.bb
@@ -29,8 +29,8 @@ do_install:append() {
     install -d ${D}${datadir}/tensorflow/lite/examples/python
     install -m 644 ${S}/tensorflow/lite/examples/python/label_image.py ${D}${datadir}/tensorflow/lite/examples/python/
     install -m 644 ${S}/tensorflow/lite/examples/label_image/testdata/grace_hopper.bmp ${D}${datadir}/tensorflow/lite/examples/python/
-    install -m 644 ${WORKDIR}/mobilenet_v1_1.0_224.tflite ${D}${datadir}/tensorflow/lite/examples/python/
-    install -m 644 ${WORKDIR}/mobilenet_v1_1.0_224/labels.txt ${D}${datadir}/tensorflow/lite/examples/python/
+    install -m 644 ${UNPACKDIR}/mobilenet_v1_1.0_224.tflite ${D}${datadir}/tensorflow/lite/examples/python/
+    install -m 644 ${UNPACKDIR}/mobilenet_v1_1.0_224/labels.txt ${D}${datadir}/tensorflow/lite/examples/python/
 }
 
 FILES:${PN} += "${datadir}/tensorflow/lite/examples/python/*"

--- a/recipes-examples/tensorflow-lite/tensorflow-lite-label-image_2.16.1.bb
+++ b/recipes-examples/tensorflow-lite/tensorflow-lite-label-image_2.16.1.bb
@@ -45,8 +45,8 @@ do_install() {
     install -d ${D}${datadir}/tensorflow/lite/examples/label_image
     install -m 755 ${B}/label_image ${D}${datadir}/tensorflow/lite/examples/label_image/
     install -m 644 ${S}/tensorflow/lite/examples/label_image/testdata/grace_hopper.bmp ${D}${datadir}/tensorflow/lite/examples/label_image/
-    install -m 644 ${WORKDIR}/mobilenet_v1_1.0_224.tflite ${D}${datadir}/tensorflow/lite/examples/label_image/
-    install -m 644 ${WORKDIR}/mobilenet_v1_1.0_224/labels.txt ${D}${datadir}/tensorflow/lite/examples/label_image/
+    install -m 644 ${UNPACKDIR}/mobilenet_v1_1.0_224.tflite ${D}${datadir}/tensorflow/lite/examples/label_image/
+    install -m 644 ${UNPACKDIR}/mobilenet_v1_1.0_224/labels.txt ${D}${datadir}/tensorflow/lite/examples/label_image/
 }
 
 FILES:${PN} += "${datadir}/tensorflow/lite/examples/label_image/*"

--- a/recipes-examples/tensorflow-lite/tensorflow-lite-minimal_2.16.1.bb
+++ b/recipes-examples/tensorflow-lite/tensorflow-lite-minimal_2.16.1.bb
@@ -41,7 +41,7 @@ OECMAKE_SOURCEPATH = "${S}/tensorflow/lite/examples/minimal"
 do_install() {
     install -d ${D}${datadir}/tensorflow/lite/examples/minimal
     install -m 755 ${B}/minimal ${D}${datadir}/tensorflow/lite/examples/minimal/
-    install -m 644 ${WORKDIR}/mobilenet_v1_1.0_224.tflite ${D}${datadir}/tensorflow/lite/examples/minimal/
+    install -m 644 ${UNPACKDIR}/mobilenet_v1_1.0_224.tflite ${D}${datadir}/tensorflow/lite/examples/minimal/
 }
 
 FILES:${PN} += "${datadir}/tensorflow/lite/examples/minimal/*"

--- a/recipes-framework/coral/libedgetpu-common.inc
+++ b/recipes-framework/coral/libedgetpu-common.inc
@@ -29,11 +29,11 @@ DEPENDS = " \
 EXTRA_OEMAKE = " libedgetpu"
 
 do_configure:prepend () {
-    export TFROOT=${WORKDIR}/tensorflow
+    export TFROOT=${UNPACKDIR}/tensorflow
 }
 
 do_compile:prepend() {
-    export TFROOT=${WORKDIR}/tensorflow
+    export TFROOT=${UNPACKDIR}/tensorflow
 }
 
 BBCLASSEXTEND = "native nativesdk"

--- a/recipes-tools/tensorflow-lite/tensorflow-lite-benchmark_2.16.1.bb
+++ b/recipes-tools/tensorflow-lite/tensorflow-lite-benchmark_2.16.1.bb
@@ -95,7 +95,7 @@ do_configure:append() {
 do_install() {
     install -d ${D}${datadir}/tensorflow/lite/tools/benchmark/
     install -m 755 ${B}/tools/benchmark/benchmark_model ${D}${datadir}/tensorflow/lite/tools/benchmark/benchmark_model
-    install -m 644 ${WORKDIR}/mobilenet_v1_1.0_224.tflite ${D}${datadir}/tensorflow/lite/tools/benchmark/
+    install -m 644 ${UNPACKDIR}/mobilenet_v1_1.0_224.tflite ${D}${datadir}/tensorflow/lite/tools/benchmark/
 }
 
 FILES:${PN} += "${datadir}/tensorflow/lite/tools/benchmark/*"


### PR DESCRIPTION
- The layer compability has also been updated.

* UNPACKDIR is new contruct for do_unpack things in latest master we should be using that instead of WORKDIR for referencing those files.

* We don't know yet what changes will be needed to stay compatible with final styhead, but we already know that the last changes for UNPACKDIR aren't compatible with scarthgap, nanbield or others.

https://lists.openembedded.org/g/openembedded-architecture/message/2007 
https://docs.yoctoproject.org/dev/ref-manual/variables.html?highlight=unpackdir#term-UNPACKDIR