### PR TITLE
Remove /usr/bin/flatc from installation

### DIFF
--- a/recipes-framework/tensorflow-lite/libtensorflow-lite_2.16.1.bb
+++ b/recipes-framework/tensorflow-lite/libtensorflow-lite_2.16.1.bb
@@ -341,6 +341,7 @@ do_install:append() {
     install -m 644 ${S}/tensorflow/lite/tools/strip_buffers/*.h ${D}${includedir}/tensorflow/lite/tools/strip_buffers
     install -m 644 ${S}/tensorflow/lite/tools/versioning/*.h ${D}${includedir}/tensorflow/lite/tools/versioning
 
+    rm -rf ${D}/${bindir}
     rm -rf ${D}/${libdir}/libflatbuffers.a
     rm -rf ${D}${includedir}/flatbuffers
     rm -rf ${D}/${libdir}/cmake/flatbuffers


### PR DESCRIPTION
When you try to install libtensorflow-lite and flatbuffers-dev, the /usr/bin/flatc file is in conflict and doesn't allow the rootfs to be created.

This resolved the build error for me, but I haven't been able to identify if anything in the c++ library depends on flatc.

If it does, would you need to make the jump to depending on flatbuffers instead of allowing tflite to build its own flat buffer?  I noticed the examples and tools depend on the flatbuffer recipe, but the c++ library does not.