### PR TITLE
docs: fix version inconsistencies, typos, and broken links in markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Please note that it is not official support.
 ### Support version
 | Recipe          | Version |
 | :--             | :--     |
-| TensorFlow Lite | v2.21.0  |
+| TensorFlow Lite | 2.21.0  |
 | libedgetpu      | e35aed18fea2e2d25d98352e5a5bd357c170bd4d |
 
 ## How to
@@ -57,7 +57,7 @@ Please note that it is not official support.
 $ git clone https://github.com/openembedded/bitbake.git
 $ git clone https://github.com/openembedded/openembedded-core.git
 $ git clone https://github.com/openembedded/meta-openembedded.git
-$ git clone git://git.yoctoproject.org/meta-raspberrypi
+$ git clone https://git.yoctoproject.org/meta-raspberrypi
 $ git clone https://github.com/NobuoTsukamoto/meta-tensorflow-lite.git
 $ source openembedded-core/oe-init-build-env build
 

--- a/doc/coral_libedgetpu.md
+++ b/doc/coral_libedgetpu.md
@@ -9,11 +9,12 @@ Build sample on Raspberry Pi 4 AArch64 (core-image-weston).
 
 ### Clone repositories and oe-init-build-env.
 ```
-git clone git://git.yoctoproject.org/poky.git
-git clone git://git.yoctoproject.org/meta-raspberrypi
-git clone git://git.openembedded.org/meta-openembedded
+git clone https://github.com/openembedded/bitbake.git
+git clone https://github.com/openembedded/openembedded-core.git
+git clone https://github.com/openembedded/meta-openembedded.git
+git clone https://git.yoctoproject.org/meta-raspberrypi
 git clone https://github.com/NobuoTsukamoto/meta-tensorflow-lite.git
-source poky/oe-init-build-env build
+source openembedded-core/oe-init-build-env build
 ```
 
 ### Add layer
@@ -32,7 +33,7 @@ Add `python3-tensorflow-lite` and `libedgetpu-nnn` recipes to `conf/auto.conf` f
   - libedgetpu-std: with reduced operating frequency ()
   - libedgetpu-max: with maximum operating frequency
 ```
-IMAGE_INSTALL:append = " python3-tensorflow-lite libedegtpu-std"
+IMAGE_INSTALL:append = " python3-tensorflow-lite libedgetpu-std"
 ```
 
 ### Bitbake
@@ -43,5 +44,5 @@ MACHINE=raspberrypi4-64 bitbake core-image-weston
 ### Warning
 If you are using Coral USB Accelerator, please check the following notes.  
 
-- [Install with maximum operating frequency (optional) - Coarl Get started with the USB Accelerator](https://coral.ai/docs/accelerator/get-started/#runtime-on-linux)
+- [Install with maximum operating frequency (optional) - Coral Get started with the USB Accelerator](https://coral.ai/docs/accelerator/get-started/#runtime-on-linux)
 - [Warning - google-coral/libedgetpu](https://github.com/google-coral/libedgetpu#warning)

--- a/doc/python3-tensorflow-lite-example.md
+++ b/doc/python3-tensorflow-lite-example.md
@@ -9,11 +9,12 @@ Build sample on Raspberry Pi 4 AArch64 (core-image-weston).
 
 ### Clone repositories and oe-init-build-env.
 ```
-git clone git://git.yoctoproject.org/poky.git
-git clone git://git.yoctoproject.org/meta-raspberrypi
-git clone git://git.openembedded.org/meta-openembedded
+git clone https://github.com/openembedded/bitbake.git
+git clone https://github.com/openembedded/openembedded-core.git
+git clone https://github.com/openembedded/meta-openembedded.git
+git clone https://git.yoctoproject.org/meta-raspberrypi
 git clone https://github.com/NobuoTsukamoto/meta-tensorflow-lite.git
-source poky/oe-init-build-env build
+source openembedded-core/oe-init-build-env build
 ```
 
 ### Add layer

--- a/doc/tensorflow-lite-benchmark.md
+++ b/doc/tensorflow-lite-benchmark.md
@@ -5,7 +5,7 @@
 - [TFLite Model Benchmark Tool with C++ Binary - tensorflow/tensorflow](https://github.com/tensorflow/tensorflow/blob/v2.21.0/tensorflow/lite/tools/benchmark/README.md)
 
 ## How to
-Build sample on qemueriscv64 (core-image-full-cmdline).
+Build sample on qemuriscv64 (core-image-full-cmdline).
 
 ### Clone repositories and oe-init-build-env.
 ```
@@ -44,7 +44,7 @@ MACHINE=qemuriscv64 runqemu nographic
 ```
 
 ### Run benchmark tool.
-login `root` and run benchmark tool.
+Login `root` and run benchmark tool.
 ```
 cd /usr/share/tensorflow/lite/tools/benchmark/
 ./benchmark_model \

--- a/doc/tensorflow-lite-benchmark.md
+++ b/doc/tensorflow-lite-benchmark.md
@@ -44,7 +44,7 @@ MACHINE=qemuriscv64 runqemu nographic
 ```
 
 ### Run benchmark tool.
-Login `root` and run benchmark tool.
+Log in as `root` and run the benchmark tool.
 ```
 cd /usr/share/tensorflow/lite/tools/benchmark/
 ./benchmark_model \

--- a/doc/tensorflow-lite-label-image.md
+++ b/doc/tensorflow-lite-label-image.md
@@ -5,7 +5,7 @@
 - [TensorFlow Lite C++ image classification demo - tensorflow/tensorflow](https://github.com/tensorflow/tensorflow/blob/v2.21.0/tensorflow/lite/examples/label_image/README.md)
 
 ## How to
-Build sample on qemueriscv64 (core-image-full-cmdline).
+Build sample on qemuriscv64 (core-image-full-cmdline).
 
 ### Clone repositories and oe-init-build-env.
 ```
@@ -44,7 +44,7 @@ MACHINE=qemuriscv64 runqemu nographic
 ```
 
 ### Run example.
-login `root` and run the example.
+Login `root` and run the example.
 ```
 cd /usr/share/tensorflow/lite/examples/label_image/
 ./label_image \

--- a/doc/tensorflow-lite-label-image.md
+++ b/doc/tensorflow-lite-label-image.md
@@ -44,7 +44,7 @@ MACHINE=qemuriscv64 runqemu nographic
 ```
 
 ### Run example.
-Login `root` and run the example.
+Log in as `root` and run the example.
 ```
 cd /usr/share/tensorflow/lite/examples/label_image/
 ./label_image \

--- a/doc/tensorflow-lite-minimal.md
+++ b/doc/tensorflow-lite-minimal.md
@@ -9,11 +9,12 @@ Build sample on Raspberry Pi 4 AArch64 (core-image-weston).
 
 ### Clone repositories and oe-init-build-env.
 ```
-git clone git://git.yoctoproject.org/poky.git
-git clone git://git.yoctoproject.org/meta-raspberrypi
-git clone git://git.openembedded.org/meta-openembedded
+git clone https://github.com/openembedded/bitbake.git
+git clone https://github.com/openembedded/openembedded-core.git
+git clone https://github.com/openembedded/meta-openembedded.git
+git clone https://git.yoctoproject.org/meta-raspberrypi
 git clone https://github.com/NobuoTsukamoto/meta-tensorflow-lite.git
-source poky/oe-init-build-env build
+source openembedded-core/oe-init-build-env build
 ```
 
 ### Add layer


### PR DESCRIPTION
This commit resolves several documentation issues:

1. Version mismatches: Updated the version string in README.md from v2.21.0 to 2.21.0 to match the recipes version.
2. Deprecated 'poky': Replaced 'poky' usage in multiple documentations with modern bitbake & openembedded-core cloning instructions.
3. Grammar and formatting errors: Fixed typos like `Coarl`, `libedegtpu-std`, and `qemueriscv64`, and fixed lowercase `login` at the start of sentences.
4. Broken links and unencrypted URLs: Replaced `git://` clone URLs with `https://`. Corrected `https://git.yoctoproject.org/meta-raspberrypi.git` which returned a 404 back to `https://git.yoctoproject.org/meta-raspberrypi` which successfully returns 200.

---
*PR created automatically by Jules for task [501350037197663662](https://jules.google.com/task/501350037197663662) started by @NobuoTsukamoto*